### PR TITLE
feat: 구매자 마이페이지 주요 기능 구현

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -97,9 +97,7 @@ exports.login = async (req, res) => {
             user = await Seller.findOne({ where: { email } });
         } 
 
-        // 비밀번호 확인
-        const passwordMatch = await bcrypt.compare(password, user.password);
-        if (!user || !passwordMatch) {
+        if (!user || !(await bcrypt.compare(password, user.password))) {
             return res.status(401).json({
                 status: 'error',
                 error: {

--- a/server/controllers/mypage-buyer/orderController.js
+++ b/server/controllers/mypage-buyer/orderController.js
@@ -1,0 +1,162 @@
+const { Order, OrderProduct, Product, DeliveryDetail, Payment, Seller, Store } = require('../../models');
+
+// 주문/배송 내역 조회
+const getMyOrders = async (req, res) => {
+  try {
+    const customerId = req.user.customer_id;
+
+    const orders = await Order.findAll({
+      where: { customer_id: customerId },
+      order: [['order_date', 'DESC']],
+      include: [
+        {
+          model: OrderProduct,
+          attributes: ['order_product_quantity', 'order_product_price'],
+          include: [
+            {
+              model: Product,
+              attributes: ['product_id', 'title']
+            }
+          ]
+        },
+        {
+          model: DeliveryDetail,
+          attributes: ['delivery_status']
+        }
+      ]
+    });
+
+    // 응답 형식 맞춰 데이터 가공
+    const formattedOrders = (orders || []).map(order => ({ 
+      order_id: order.order_id ?? null, 
+      order_date: order.order_date ?? null, 
+      order_price: order.order_price ?? null, 
+      order_state: order.order_state ?? null, 
+      delivery_status: order.DeliveryDetail?.delivery_status || null,
+      receiver_name: order.receiver_name ?? null, 
+      street: order.street ?? null, 
+      itemsPreview: order.OrderProducts.map(item => ({
+        product_id: item.Product.product_id ?? null, 
+        product_name: item.Product.title ?? null, 
+        quantity: item.order_product_quantity ?? null, 
+        price: item.order_product_price ?? null, 
+      }))
+    }));
+
+    res.status(200).json({
+      status: 'success',
+      data: formattedOrders
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({
+      status: 'error',
+      code: 'SERVER_ERROR',
+      message: '서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
+    });
+  }
+};
+
+
+// 주문/배송 내역 상세 조회
+const getMyOrderDetail = async (req, res) => {
+  try {
+    const customerId = req.user.customer_id;
+    const { order_id } = req.params;
+
+    // 주문 조회 (주문상품, 상품, 판매자, 스토어, 배송, 결제 정보 포함)
+    const order = await Order.findOne({
+      where: {
+        order_id,
+        customer_id: customerId
+      },
+      include: [
+        {
+          model: OrderProduct,
+          include: [
+            {
+              model: Product,
+              attributes: ['product_id', 'title'],
+              include: [
+                {
+                  model: Seller,
+                  attributes: ['seller_id'],
+                  include: [
+                    {
+                      model: Store,
+                      attributes: ['name'] // 스토어 이름
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          model: DeliveryDetail
+        },
+        {
+          model: Payment
+        }
+      ]
+    });
+
+    if (!order) {
+      return res.status(404).json({
+        status: 'error',
+        message: '해당 주문을 찾을 수 없습니다.'
+      });
+    }
+
+    // 응답 포맷
+    const formattedOrder = {
+      order_id: order.order_id,
+      order_date: order.order_date,
+      order_price: order.order_price,
+      order_state: order.order_state,
+      deliveryInfo: {
+        delivery_status: order.DeliveryDetail?.delivery_status || null,
+        tracking_number: order.DeliveryDetail?.tracking_number || null,
+        courier: order.DeliveryDetail?.courier || null,
+        receiver_name: order.receiver_name,
+        receiver_phone: order.receiver_phone,
+        deliveryAddress: {
+          zipCode: order.zip_code,
+          street: order.street,
+          detail: order.detail
+        },
+        delivered_at: order.DeliveryDetail?.delivered_at || null,
+        deliveryHistory: []
+      },
+      orderItems: order.OrderProducts.map(item => ({
+        order_product_id: item.order_product_id,
+        product_id: item.Product?.product_id,
+        product_name: item.Product?.title,
+        order_product_quantity: item.order_product_quantity,
+        order_product_price: item.order_product_price,
+        sellerName: item.Product?.Seller?.Store?.name || null
+      })),
+      paymentInfo: {
+        approved_at: order.Payment?.approved_at || null,
+        amount: order.Payment?.amount || 0,
+        method: order.Payment?.method || null,
+        discountAmount: 0,
+        couponUsed: null
+      }
+    };
+
+    res.status(200).json({
+      status: 'success',
+      data: formattedOrder
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({
+      status: 'error',
+      code: 'SERVER_ERROR',
+      message: '서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
+    });
+  }
+};
+
+module.exports = { getMyOrders, getMyOrderDetail };

--- a/server/controllers/mypage-buyer/profileController.js
+++ b/server/controllers/mypage-buyer/profileController.js
@@ -1,0 +1,99 @@
+const bcrypt = require('bcrypt');
+const { Customer } = require('../../models');
+
+const getProfile = async (req, res) => {
+    try {
+        const user = req.user; // authMiddleware에서 설정한 사용자 정보
+
+        res.status(200).json({
+            status: 'success',
+            data: {
+                customer_id: user.customer_id,
+                email: user.email,
+                nickname: user.nickname,
+                phone: user.phone,
+                user_type: user.user_type,
+                address: {
+                zipCode: user.zip_code,
+                street: user.street,
+                detail: user.detail
+                },
+                profile_image: user.profile_image
+            }
+        });
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ 
+            status: 'error',
+            code: 'SERVER_ERROR',
+            message: '서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+        });
+    } 
+};
+
+const updateProfile = async (req, res) => {
+    try {
+        const user = req.user;
+        const {
+            nickname,
+            phone,
+            zip_code,
+            street,
+            detail,
+            password
+        } = req.body;
+
+        const updateData = {
+            nickname,
+            phone: phone,
+            zip_code: zip_code,
+            street: street,
+            detail: detail
+        };
+
+        // 비밀번호 변경하는 경우, 해시 처리
+        if (password) {
+            const isSame = await bcrypt.compare(password, user.password); // 기존 비밀번호와 동일한 경우
+            if (!isSame) {
+                const hash = await bcrypt.hash(password, 10);
+                updateData.password = hash;
+            }
+        }
+
+        // DB 업데이트
+        await Customer.update(updateData, { 
+            where: { customer_id: user.customer_id }
+        });
+
+        // 업데이트된 사용자 정보 
+        const updatedUser = await Customer.findByPk(user.customer_id);
+
+    res.status(200).json({
+        status: 'success',
+        data: {
+            customer_id: updatedUser.customer_id,
+            email: updatedUser.email,
+            nickname: updatedUser.nickname,
+            phone: updatedUser.phone,
+            user_type: updatedUser.user_type,
+            zip_code: updatedUser.zip_code,
+            street: updatedUser.street,
+            detail: updatedUser.detail,
+            profile_image: updatedUser.profile_image,
+            created_at: updatedUser.created_at,
+            updated_at: updatedUser.updated_at
+        }
+        });
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ 
+            status: 'error',
+            code: 'SERVER_ERROR',
+            message: '서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+        });
+    }
+};
+
+module.exports = {
+    getProfile, updateProfile
+};

--- a/server/controllers/mypage-buyer/refundController.js
+++ b/server/controllers/mypage-buyer/refundController.js
@@ -1,0 +1,167 @@
+const { Refund, Payment, Order, OrderProduct, Product } = require('../../models');
+
+// 취소/반품 내역 조회
+const getMyCancellations = async (req, res) => {
+  try {
+    const customerId = req.user.customer_id; // 로그인된 사용자 ID 가져오기
+
+    // 페이지네이션 정보 설정
+    const page = parseInt(req.query.page) || 1;
+    const pageSize = parseInt(req.query.pageSize) || 10;
+    const offset = (page - 1) * pageSize;
+
+    // 전체 환불 건수 조회
+    const totalElements = await Refund.count({
+      include: [{
+        model: Payment,
+        include: [{
+          model: Order,
+          where: { customer_id: customerId }
+        }]
+      }]
+    });
+
+    // 환불 목록 조회
+    const refunds = await Refund.findAll({
+    include: [
+        {
+        model: Payment,
+        include: [
+            {
+            model: Order,
+            where: { customer_id: customerId },
+            attributes: ['order_id'],
+            include: [
+                {
+                model: OrderProduct,
+                attributes: ['order_product_id'], 
+                include: [
+                    {
+                    model: Product,
+                    attributes: ['title']
+                    }
+                ]
+                }
+            ]
+            }
+        ]
+        }
+    ],
+    limit: pageSize,
+    offset,
+    order: [['created_at', 'DESC']]
+    });
+
+    // 응답 매핑
+    const cancellations = (refunds || []).map(refund => ({
+        refund_id: refund.refund_id ?? null, 
+        order_id: refund.Payment?.Order?.order_id ?? null, 
+        product_name: refund.Payment?.Order?.OrderProducts?.[0]?.Product?.title || null, // 상품명 조인
+        amount: refund.amount ?? null, 
+        created_at: refund.created_at ?? null, 
+        status: refund.status ?? null, 
+    }));
+
+    res.status(200).json({
+      status: 'success',
+      data: {
+        cancellations,
+        pagination: {
+          currentPage: page,
+          totalPages: Math.ceil(totalElements / pageSize),
+          totalElements,
+          pageSize
+        }
+      }
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({
+      status: 'error',
+      code: 'SERVER_ERROR',
+      message: '서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
+    });
+  }
+};
+
+
+// 취소/반품 내역 상세 조회
+const getCancellationDetail = async (req, res) => {
+  try {
+    const { refund_id } = req.params; 
+
+    // 환불 1건 상세 조회
+    const refund = await Refund.findOne({
+      where: { refund_id },
+      include: [
+        {
+          model: Payment,
+          include: [
+            {
+              model: Order,
+              attributes: ['order_id'],
+              include: [
+                {
+                  model: OrderProduct,
+                  include: [
+                    {
+                      model: Product,
+                      attributes: ['title']
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+
+    if (!refund || !refund.Payment || !refund.Payment.Order) {
+      return res.status(404).json({ status: 'error', message: '데이터를 찾을 수 없습니다.' });
+    }
+
+    const order = refund.Payment.Order;
+    const orderProducts = order.OrderProducts || [];
+
+    // 상품명 조합 및 수량 계산
+    const mainProduct = orderProducts[0]?.Product?.title || '';
+    let product_name = mainProduct;
+    if (orderProducts.length > 1) {
+      product_name += ` 외 ${orderProducts.length - 1}개`;
+    }
+    const quantity = orderProducts.reduce((sum, op) => sum + (op.order_product_quantity || 0), 0);
+
+    res.status(200).json({
+      status: 'success',
+      data: {
+        cancellation: {
+          refund_id: refund.refund_id,
+          order_id: order.order_id,
+          product_name,
+          quantity,
+          amount: refund.amount,
+          reason: refund.reason,
+          created_at: refund.created_at,
+          refunded_at: refund.refunded_at,
+          status: refund.status,
+          paymentInfo: {
+            method: refund.Payment.method,
+            amount: refund.Payment.amount
+          },
+          refundStatus: refund.status // 상태 코드와 동일하게 처리
+        }
+      }
+    });
+
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({
+      status: 'error',
+      code: 'SERVER_ERROR',
+      message: '서버 내부 오류가 발생했습니다.'
+    });
+  }
+};
+
+module.exports = { getMyCancellations, getCancellationDetail };

--- a/server/controllers/mypage-buyer/reviewController.js
+++ b/server/controllers/mypage-buyer/reviewController.js
@@ -1,0 +1,67 @@
+const { Review, Product, ProductImg } = require('../../models');
+
+const getMyReviews = async (req, res) => {
+    try {
+        const customerId = req.user.customer_id;
+        
+        // 페이지 정보
+        const page = parseInt(req.query.page) || 1;
+        const pageSize = parseInt(req.query.pageSize) || 10;
+        const offset = (page - 1) * pageSize;
+
+        // 전체 리뷰 개수
+        const totalElements = await Review.count({
+            where: { customer_id: customerId }
+        });
+
+        const reviews = await Review.findAll({
+        where: { customer_id: customerId },
+        include: [
+            {
+            model: Product,
+            attributes: ['product_id', 'title'],
+            include: [
+                { model: ProductImg, attributes: ['img_url'], required: false }
+            ]
+            }
+        ],
+        limit: pageSize,
+        offset,
+        order: [['created_date', 'DESC']]
+        });
+
+        // 응답 형식에 맞춰 매핑
+        const result = (reviews || []).map(item => ({
+            review_id: item?.review_id ?? null,
+            rating: item?.rating ?? null,
+            content: item?.content ?? null,
+            img_url: item?.img_url ?? null,
+            product_id: item?.Product?.product_id ?? null,
+            product_name: item?.Product?.title ?? null,
+            product_img_url: item?.Product?.ProductImgs?.[0]?.img_url ?? null,
+            created_at: item?.created_date ?? null
+        }));
+
+        res.status(200).json({
+          status: 'success',
+          data: {
+            result,
+            pagination: {
+            currentPage: page,
+            totalPages: Math.ceil(totalElements / pageSize),
+            totalElements,
+            pageSize
+            }
+          }
+        });
+    } catch (err) {
+        console.error(err);
+        res.status(500).json({
+            status: 'error',
+            code: 'SERVER_ERROR',
+            message: '서버 내부 오류가 발생했습니다.'
+        });
+    }
+};
+
+module.exports = { getMyReviews };

--- a/server/controllers/mypage-buyer/wishlistController.js
+++ b/server/controllers/mypage-buyer/wishlistController.js
@@ -1,0 +1,124 @@
+const { StoreWishlist, Store, ProductWishlist, Product, ProductImg } = require('../../models');
+
+// 스토어 즐겨찾기 목록 조회
+const getFavoriteStores = async (req, res) => {
+    try {
+        const customerId = req.user.customer_id;
+        
+        // 페이지 정보
+        const page = parseInt(req.query.page) || 1;
+        const pageSize = parseInt(req.query.pageSize) || 10;
+        const offset = (page - 1) * pageSize;
+
+        // 전체 즐겨찾기 개수
+        const totalElements = await StoreWishlist.count({
+            where: { customer_id: customerId }
+        });
+
+        const favorites = await StoreWishlist.findAll({
+        where: { customer_id: customerId },
+        include: [
+            {
+            model: Store,
+            attributes: ['store_id', 'name'],
+            }
+        ],
+        limit: pageSize,
+        offset,
+        order: [['created_at', 'DESC']]
+        });
+
+        // 응답 형식에 맞춰 매핑
+        const favoriteStores = (favorites || []).map(fav => ({
+            store_wishlist_id: fav.store_wishlist_id ?? null, 
+            store_id: fav.Store?.store_id ?? null, 
+            store_name: fav.Store?.name ?? null, 
+            created_at: fav.created_at ?? null, 
+        }));
+
+        res.status(200).json({
+          status: 'success',
+          data: {
+            favoriteStores,
+            pagination: {
+            currentPage: page,
+            totalPages: Math.ceil(totalElements / pageSize),
+            totalElements,
+            pageSize
+            }
+          }
+        });
+
+    } catch (err) {
+    console.error(err);
+    res.status(500).json({
+        status: 'error',
+        code: 'SERVER_ERROR',
+        message: '서버 내부 오류가 발생했습니다.'
+    });
+    }
+}
+
+// 상품 찜 목록 조회
+const getProductWishlists = async (req, res) => {
+    try {
+        const customerId = req.user.customer_id;
+        
+        const page = parseInt(req.query.page) || 1;
+        const pageSize = parseInt(req.query.pageSize) || 10;
+        const offset = (page - 1) * pageSize;
+
+        const totalElements = await ProductWishlist.count({
+            where: { customer_id: customerId }
+        });
+
+        const wishlists = await ProductWishlist.findAll({
+        where: { customer_id: customerId },
+        include: [
+            {
+            model: Product,
+            attributes: ['product_id', 'title', 'price'],
+            include: [
+                { model: ProductImg, attributes: ['img_url'], required: false }
+            ]
+            }
+        ],
+        limit: pageSize,
+        offset,
+        order: [['created_at', 'DESC']]
+        });
+
+        // 응답 형식에 맞춰 매핑
+        const productWishlists = (wishlists || []).map(wish => ({
+            product_wishlist_id: wish.product_wishlist_id ?? null, 
+            product_id: wish.Product?.product_id ?? null, 
+            product_name: wish.Product?.title ?? null, 
+            price: wish.Product?.price ?? null, 
+            img_url: wish.Product?.ProductImg?.[0]?.img_url || null,
+            created_at: wish.created_at ?? null, 
+        }));
+
+        res.status(200).json({
+          status: 'success',
+          data: {
+            productWishlists,
+            pagination: {
+            currentPage: page,
+            totalPages: Math.ceil(totalElements / pageSize),
+            totalElements,
+            pageSize
+            }
+          }
+        });
+
+    } catch (err) {
+    console.error(err);
+    res.status(500).json({
+        status: 'error',
+        code: 'SERVER_ERROR',
+        message: '서버 내부 오류가 발생했습니다.'
+    });
+    }
+}
+
+module.exports = { getFavoriteStores, getProductWishlists };

--- a/server/controllers/recommendController.js
+++ b/server/controllers/recommendController.js
@@ -1,0 +1,2 @@
+const { Customer, Product, Category, Order, ProductWishlist, StoreWishlist } = require('../models');
+

--- a/server/middlewares/authMiddleware.js
+++ b/server/middlewares/authMiddleware.js
@@ -1,0 +1,37 @@
+const jwt = require('jsonwebtoken');
+const { Customer, Seller } = require('../models'); // 일단 seller 추가해둠
+require('dotenv').config();
+
+const authMiddleware = async (req, res, next) => {
+    try {
+        const authHeader = req.headers.authorization; // 
+
+        if (!authHeader || !authHeader.startsWith('Bearer ')) {
+            return res.status(401).json({ message: '인증 정보가 없습니다.' });
+        }
+
+        const token = authHeader.split(' ')[1];
+        const decoded = jwt.verify(token, process.env.JWT_SECRET); // jwt 복호화
+
+        let user;
+
+        if (decoded.user_type === 'buyer') {
+            user = await Customer.findByPk(decoded.id);
+        } else if (decode.user_type === 'seller') {
+            user = await Seller.findByPk(decoded.id);
+        }
+
+        if (!user) {
+            return res.status(401).json({ message: '사용자를 찾을 수 없습니다.' });
+        }
+
+        req.user = user;
+        next();
+
+    } catch (err) {
+        console.error('인증 실패:', err);
+    return res.status(401).json({ message: '유효하지 않거나 만료된 토큰입니다.' });
+    }
+};
+
+module.exports = authMiddleware;

--- a/server/migrations/20250723140000-create-category.js
+++ b/server/migrations/20250723140000-create-category.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('category', {
+      category_id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.BIGINT,
+      },
+      category_name: {
+        type: Sequelize.STRING(100),
+        allowNull: false,
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('category');
+  }
+};

--- a/server/migrations/20250723140100-create-direct-store.js
+++ b/server/migrations/20250723140100-create-direct-store.js
@@ -1,0 +1,48 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('direct_store', {
+      direct_store_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      seller_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'seller', // 외래키 연결 대상 테이블
+          key: 'seller_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      name: {
+        type: Sequelize.STRING(100),
+        allowNull: false,
+      },
+      address: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      latitude: {
+        type: Sequelize.FLOAT,
+        allowNull: false,
+      },
+      longitude: {
+        type: Sequelize.FLOAT,
+        allowNull: false,
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('direct_store');
+  }
+};

--- a/server/migrations/20250723140200-create-product.js
+++ b/server/migrations/20250723140200-create-product.js
@@ -1,0 +1,92 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('product', {
+      product_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      category_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'category',
+          key: 'category_id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      seller_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'seller',
+          key: 'seller_id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      direct_store_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'direct_store',
+          key: 'direct_store_id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      title: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      status: {
+        type: Sequelize.ENUM('판매중', '품절', '판매 중지'),
+        allowNull: false,
+      },
+      weight: {
+        type: Sequelize.STRING(50),
+        allowNull: false,
+      },
+      price: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      description: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      intro: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      is_video: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+      },
+      video_url: {
+        type: Sequelize.STRING(500),
+        allowNull: true,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      returnable: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('product');
+  }
+};

--- a/server/migrations/20250723140300-create-product-img.js
+++ b/server/migrations/20250723140300-create-product-img.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('product_img', {
+      img_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      product_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'product', // 외래키 참조 테이블명
+          key: 'product_id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      img_url: {
+        type: Sequelize.STRING(500),
+        allowNull: false,
+      },
+      img_order: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('product_img');
+  }
+};

--- a/server/migrations/20250723142952-create-coupon.js
+++ b/server/migrations/20250723142952-create-coupon.js
@@ -1,0 +1,58 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('coupon', {
+      coupon_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      name: {
+        type: Sequelize.STRING(30),
+        allowNull: false,
+      },
+      type: {
+        type: Sequelize.ENUM('percent', 'amount'),
+        allowNull: false,
+      },
+      value: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      min_order_account: {
+        type: Sequelize.DECIMAL(10, 2),
+        allowNull: true,
+      },
+      max_discount: {
+        type: Sequelize.DECIMAL(10, 2),
+        allowNull: true,
+      },
+      is_available: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      closed_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      valid_from: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      valid_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('coupon');
+  }
+};

--- a/server/migrations/20250723143000-create-voucher-product.js
+++ b/server/migrations/20250723143000-create-voucher-product.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('voucher_product', {
+      voucher_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true
+      },
+      voucher_name: {
+        type: Sequelize.STRING(100),
+        allowNull: false
+      },
+      amount: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      valid_date: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      refundable_date: {
+        type: Sequelize.DATE,
+        allowNull: false
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('voucher_product');
+  }
+};

--- a/server/migrations/20250723143007-create-issue-coupon.js
+++ b/server/migrations/20250723143007-create-issue-coupon.js
@@ -1,0 +1,46 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('issue_coupon', {
+      issue_coupon_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      coupon_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'coupon',
+          key: 'coupon_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      customer_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'customer',
+          key: 'customer_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      issued_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      status: {
+        type: Sequelize.ENUM('issued', 'used', 'expired'),
+        allowNull: false
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('issue_coupon');
+  }
+};

--- a/server/migrations/20250723143017-create-voucher-usage.js
+++ b/server/migrations/20250723143017-create-voucher-usage.js
@@ -1,0 +1,38 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('voucher_usage', {
+      voucher_usage_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      user_voucher_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false
+      },
+      used_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      used_amount: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      remaining_amount: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      used_in: {
+        type: Sequelize.STRING,
+        allowNull: false
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('voucher_usage');
+  }
+};

--- a/server/migrations/20250723143022-create-issue-voucher.js
+++ b/server/migrations/20250723143022-create-issue-voucher.js
@@ -1,0 +1,61 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('issue_voucher', {
+      user_voucher_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true
+      },
+      customer_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'customer',
+          key: 'customer_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      voucher_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'voucher_product',
+          key: 'voucher_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      voucher_usage_id: {
+        type: Sequelize.BIGINT,
+        allowNull: true
+      },
+      acquired_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      expired_at: {
+        type: Sequelize.DATEONLY,
+        allowNull: false
+      },
+      used_amount: {
+        type: Sequelize.INTEGER,
+        allowNull: true
+      },
+      remaining_amount: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      status: {
+        type: Sequelize.ENUM('active', 'used', 'expired'),
+        allowNull: false
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('issue_voucher');
+  }
+};

--- a/server/migrations/20250723143027-create-order.js
+++ b/server/migrations/20250723143027-create-order.js
@@ -1,0 +1,88 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('order', {
+      order_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      customer_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'customer',
+          key: 'customer_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      address_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false
+      },
+      issue_coupon_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'issue_coupon',
+          key: 'issue_coupon_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      user_voucher_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'issue_voucher',
+          key: 'user_voucher_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      order_date: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      order_state: {
+        type: Sequelize.ENUM('결제 완료', '배송중', '배송완료', '주문취소'),
+        allowNull: false
+      },
+      delivery_type: {
+        type: Sequelize.ENUM('일반 배송', '바로 배송', '바로 찾음', '정기 배송'),
+        allowNull: false
+      },
+      order_shipping_fee: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      order_price: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      receiver_name: {
+        type: Sequelize.STRING(50),
+        allowNull: false
+      },
+      receiver_phone: {
+        type: Sequelize.STRING(20),
+        allowNull: false
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: true
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('order');
+  }
+};

--- a/server/migrations/20250723143032-create-order-product.js
+++ b/server/migrations/20250723143032-create-order-product.js
@@ -1,0 +1,54 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('order_product', {
+      order_product_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      order_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'order',
+          key: 'order_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      product_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'product',
+          key: 'product_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      order_product_quantity: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      order_product_price: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      total_price: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('order_product');
+  }
+};

--- a/server/migrations/20250723143040-create-delivery-detail.js
+++ b/server/migrations/20250723143040-create-delivery-detail.js
@@ -1,0 +1,56 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('delivery_detail', {
+      delivery_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      order_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'order',
+          key: 'order_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      pickup_time: {
+        type: Sequelize.DATE,
+        allowNull: true
+      },
+      subscription_cycle: {
+        type: Sequelize.STRING(50),
+        allowNull: true
+      },
+      delivered_at: {
+        type: Sequelize.DATE,
+        allowNull: true
+      },
+      is_delivered: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false
+      },
+      delivery_status: {
+        type: Sequelize.ENUM('배송준비', '배송중', '배송완료'),
+        allowNull: false
+      },
+      tracking_number: {
+        type: Sequelize.BIGINT,
+        allowNull: false
+      },
+      courier: {
+        type: Sequelize.STRING,
+        allowNull: false
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('delivery_detail');
+  }
+};

--- a/server/migrations/20250723143050-create-payment.js
+++ b/server/migrations/20250723143050-create-payment.js
@@ -1,0 +1,60 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('payment', {
+      payment_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      order_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'order',
+          key: 'order_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      pg_provider: {
+        type: Sequelize.STRING(50),
+        allowNull: false
+      },
+      method: {
+        type: Sequelize.STRING(50),
+        allowNull: false
+      },
+      amount: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      status: {
+        type: Sequelize.ENUM('성공', '실패', '취소', '처리중'),
+        allowNull: false
+      },
+      pg_tid: {
+        type: Sequelize.STRING(100),
+        allowNull: true
+      },
+      approved_at: {
+        type: Sequelize.DATE,
+        allowNull: true
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: true
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('payment');
+  }
+};

--- a/server/migrations/20250723143056-create-refund.js
+++ b/server/migrations/20250723143056-create-refund.js
@@ -1,0 +1,48 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('refund', {
+      refund_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      payment_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'payment',
+          key: 'payment_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      amount: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      reason: {
+        type: Sequelize.STRING(500),
+        allowNull: false
+      },
+      status: {
+        type: Sequelize.ENUM('완료', '거절', '요청됨', '승인됨'),
+        allowNull: false
+      },
+      refunded_at: {
+        type: Sequelize.DATE,
+        allowNull: true
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('refund');
+  }
+};

--- a/server/migrations/20250723151737-create-customer-address.js
+++ b/server/migrations/20250723151737-create-customer-address.js
@@ -1,0 +1,49 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('customer_address', {
+      address_id: {
+        type: Sequelize.BIGINT,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      customer_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'customer',
+          key: 'customer_id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      address_line: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      latitude: {
+        type: Sequelize.FLOAT,
+        allowNull: false,
+      },
+      longitude: {
+        type: Sequelize.FLOAT,
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('customer_address');
+  },
+};

--- a/server/migrations/20250726073808-create-store-wishlist.js
+++ b/server/migrations/20250726073808-create-store-wishlist.js
@@ -1,0 +1,42 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('store_wishlist', {
+      store_wishlist_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      store_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'store',
+          key: 'store_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      customer_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'customer',
+          key: 'customer_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: true
+      }
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('store_wishlist');
+  }
+};

--- a/server/migrations/20250726073839-create-product-wishlist.js
+++ b/server/migrations/20250726073839-create-product-wishlist.js
@@ -1,0 +1,42 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('product_wishlist', {
+      product_wishlist_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      product_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'product',
+          key: 'product_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      customer_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: {
+          model: 'customer',
+          key: 'customer_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: true
+      }
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('product_wishlist');
+  }
+};

--- a/server/migrations/20250727132128-create-review.js
+++ b/server/migrations/20250727132128-create-review.js
@@ -1,0 +1,48 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('review', {
+      review_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true
+      },
+      customer_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: { model: 'customer', key: 'customer_id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      product_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        references: { model: 'product', key: 'product_id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      content: {
+        type: Sequelize.STRING(1000),
+        allowNull: false
+      },
+      rating: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      img_url: {
+        type: Sequelize.STRING(200),
+        allowNull: true
+      },
+      created_date: {
+        type: Sequelize.DATE,
+        allowNull: false
+      }
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('review');
+  }
+};

--- a/server/models/category.js
+++ b/server/models/category.js
@@ -1,0 +1,28 @@
+// server/models/category.js
+module.exports = (sequelize, DataTypes) => {
+  const Category = sequelize.define('Category', {
+    category_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    category_name: {
+      type: DataTypes.STRING(100),
+      allowNull: false,
+    }
+  }, {
+    tableName: 'category',
+    timestamps: false,
+    underscored: true,
+  });
+
+  Category.associate = (models) => {
+    Category.hasMany(models.Product, {
+      foreignKey: 'category_id',
+      sourceKey: 'category_id',
+    });
+  };
+  
+  return Category;
+};

--- a/server/models/coupon.js
+++ b/server/models/coupon.js
@@ -1,0 +1,64 @@
+// server/models/coupon.js
+module.exports = (sequelize, DataTypes) => {
+  const Coupon = sequelize.define('Coupon', {
+    coupon_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    name: {
+      type: DataTypes.STRING(30),
+      allowNull: false
+    },
+    type: {
+      type: DataTypes.ENUM('percent', 'amount'),
+      allowNull: false
+    },
+    value: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    min_order_account: {
+      type: DataTypes.DECIMAL(10, 2),
+      allowNull: true
+    },
+    max_discount: {
+      type: DataTypes.DECIMAL(10, 2),
+      allowNull: true
+    },
+    is_available: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    closed_at: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
+    valid_from: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    valid_at: {
+      type: DataTypes.DATE,
+      allowNull: false
+    }
+  }, {
+    tableName: 'coupon',
+    timestamps: false,
+    underscored: true
+  });
+
+  Coupon.associate = (models) => {
+    Coupon.hasMany(models.IssueCoupon, {
+      foreignKey: 'coupon_id',
+      sourceKey: 'coupon_id'
+    });
+  };
+
+  return Coupon;
+};

--- a/server/models/customer_address.js
+++ b/server/models/customer_address.js
@@ -1,0 +1,54 @@
+// server/models/customer_address.js
+module.exports = (sequelize, DataTypes) => {
+  const CustomerAddress = sequelize.define('CustomerAddress', {
+    address_id: {
+      type: DataTypes.BIGINT,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    customer_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: 'customer',
+        key: 'customer_id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+    },
+    address_line: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    latitude: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    },
+    longitude: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  }, {
+    tableName: 'customer_address',
+    timestamps: false,
+    underscored: true,
+  });
+
+  CustomerAddress.associate = (models) => {
+    CustomerAddress.belongsTo(models.Customer, {
+      foreignKey: 'customer_id',
+      targetKey: 'customer_id',
+    });
+  };
+
+  return CustomerAddress;
+};

--- a/server/models/delivery_detail.js
+++ b/server/models/delivery_detail.js
@@ -1,0 +1,56 @@
+// server/models/delivery_detail.js
+module.exports = (sequelize, DataTypes) => {
+  const DeliveryDetail = sequelize.define('DeliveryDetail', {
+    delivery_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    order_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false
+    },
+    pickup_time: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
+    subscription_cycle: {
+      type: DataTypes.STRING(50),
+      allowNull: true
+    },
+    delivered_at: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
+    is_delivered: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false
+    },
+    delivery_status: {
+      type: DataTypes.ENUM('배송준비', '배송중', '배송완료'),
+      allowNull: false
+    },
+    tracking_number: {
+      type: DataTypes.BIGINT,
+      allowNull: false
+    },
+    courier: {
+      type: DataTypes.STRING,
+      allowNull: false
+    }
+  }, {
+    tableName: 'delivery_detail',
+    timestamps: false,
+    underscored: true
+  });
+
+  DeliveryDetail.associate = (models) => {
+    DeliveryDetail.belongsTo(models.Order, {
+      foreignKey: 'order_id',
+      targetKey: 'order_id'
+    });
+  };
+
+  return DeliveryDetail;
+};

--- a/server/models/direct_store.js
+++ b/server/models/direct_store.js
@@ -1,0 +1,54 @@
+// server/models/direct_store.js
+module.exports = (sequelize, DataTypes) => {
+  const DirectStore = sequelize.define('DirectStore', {
+    direct_store_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    seller_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING(100),
+      allowNull: false,
+    },
+    address: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    latitude: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    },
+    longitude: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    }
+  }, {
+    tableName: 'direct_store',
+    modelName: 'DirectStore',
+    timestamps: false,
+    underscored: true,
+  });
+
+  DirectStore.associate = (models) => {
+    DirectStore.belongsTo(models.Seller, {
+      foreignKey: 'seller_id',
+      targetKey: 'seller_id',
+    });
+
+    DirectStore.hasMany(models.Product, {
+      foreignKey: 'direct_store_id',
+      sourceKey: 'direct_store_id',
+    });
+  };
+
+  return DirectStore;
+};

--- a/server/models/issue_coupon.js
+++ b/server/models/issue_coupon.js
@@ -1,0 +1,50 @@
+// server/models/issue_coupon.js
+module.exports = (sequelize, DataTypes) => {
+  const IssueCoupon = sequelize.define('IssueCoupon', {
+    issue_coupon_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    coupon_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false
+    },
+    customer_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false
+    },
+    issued_at: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    status: {
+      type: DataTypes.ENUM('issued', 'used', 'expired'),
+      allowNull: false
+    }
+  }, {
+    tableName: 'issue_coupon',
+    timestamps: false,
+    underscored: true
+  });
+
+  IssueCoupon.associate = (models) => {
+    IssueCoupon.belongsTo(models.Coupon, {
+      foreignKey: 'coupon_id',
+      targetKey: 'coupon_id'
+    });
+
+    IssueCoupon.belongsTo(models.Customer, {
+      foreignKey: 'customer_id',
+      targetKey: 'customer_id'
+    });
+
+    IssueCoupon.hasMany(models.Order, {
+      foreignKey: 'issue_coupon_id',
+      sourceKey: 'issue_coupon_id'
+    });
+  };
+
+  return IssueCoupon;
+};

--- a/server/models/issue_voucher.js
+++ b/server/models/issue_voucher.js
@@ -1,0 +1,58 @@
+
+module.exports = (sequelize, DataTypes) => {
+  const IssueVoucher = sequelize.define('IssueVoucher', {
+    user_voucher_id: {
+      type: DataTypes.BIGINT,
+      primaryKey: true,
+      allowNull: false,
+    },
+    customer_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    voucher_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    voucher_usage_id: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
+    acquired_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    expired_at: {
+      type: DataTypes.DATEONLY,
+      allowNull: false,
+    },
+    used_amount: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    remaining_amount: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.ENUM('active', 'used', 'expired'),
+      allowNull: false,
+    },
+  }, {
+    tableName: 'issue_voucher',
+    timestamps: false,
+  });
+
+  IssueVoucher.associate = models => {
+    IssueVoucher.belongsTo(models.Customer, {
+      foreignKey: 'customer_id',
+      targetKey: 'customer_id',
+    });
+    IssueVoucher.belongsTo(models.VoucherUsage, {
+      foreignKey: 'voucher_usage_id',
+      targetKey: 'voucher_usage_id',
+    });
+  };
+
+  return IssueVoucher;
+};

--- a/server/models/order.js
+++ b/server/models/order.js
@@ -1,0 +1,91 @@
+// server/models/order.js
+module.exports = (sequelize, DataTypes) => {
+  const Order = sequelize.define('Order', {
+    order_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    customer_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    address_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    issue_coupon_id: {
+      type: DataTypes.BIGINT,
+      allowNull: true, // 
+    },
+    user_voucher_id: {
+      type: DataTypes.BIGINT,
+      allowNull: true, //
+    },
+    order_date: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    order_state: {
+      type: DataTypes.ENUM('결제 완료', '배송중', '배송완료', '주문취소'),
+      allowNull: false,
+    },
+    delivery_type: {
+      type: DataTypes.ENUM('일반 배송', '바로 배송', '바로 찾음', '정기 배송'),
+      allowNull: false,
+    },
+    order_shipping_fee: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    order_price: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    receiver_name: {
+      type: DataTypes.STRING(50),
+      allowNull: false,
+    },
+    receiver_phone: {
+      type: DataTypes.STRING(20),
+      allowNull: false,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    }
+  }, {
+    tableName: 'order',
+    timestamps: false,
+    underscored: true,
+  });
+
+  Order.associate = (models) => {
+    Order.belongsTo(models.Customer, {
+      foreignKey: 'customer_id',
+      targetKey: 'customer_id',
+    });
+
+    Order.hasMany(models.OrderProduct, {
+      foreignKey: 'order_id',
+      sourceKey: 'order_id',
+    });
+
+    Order.hasOne(models.DeliveryDetail, {
+      foreignKey: 'order_id',
+      sourceKey: 'order_id',
+    });
+
+    Order.hasOne(models.Payment, {
+      foreignKey: 'order_id',
+      sourceKey: 'order_id',
+    });
+  };
+
+  return Order;
+};

--- a/server/models/order_product.js
+++ b/server/models/order_product.js
@@ -1,0 +1,53 @@
+// server/models/order_product.js
+module.exports = (sequelize, DataTypes) => {
+  const OrderProduct = sequelize.define('OrderProduct', {
+    order_product_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    order_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false
+    },
+    product_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false
+    },
+    order_product_quantity: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    order_product_price: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    total_price: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false
+    }
+  }, {
+    tableName: 'order_product',
+    timestamps: false,
+    underscored: true
+  });
+
+  OrderProduct.associate = (models) => {
+    OrderProduct.belongsTo(models.Order, {
+      foreignKey: 'order_id',
+      targetKey: 'order_id'
+    });
+
+    OrderProduct.belongsTo(models.Product, {
+      foreignKey: 'product_id',
+      targetKey: 'product_id'
+    });
+  };
+
+  return OrderProduct;
+};

--- a/server/models/payment.js
+++ b/server/models/payment.js
@@ -1,0 +1,60 @@
+// server/models/payment.js
+module.exports = (sequelize, DataTypes) => {
+  const Payment = sequelize.define('Payment', {
+    payment_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    order_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false
+    },
+    pg_provider: {
+      type: DataTypes.STRING(50),
+      allowNull: false
+    },
+    method: {
+      type: DataTypes.STRING(50),
+      allowNull: false
+    },
+    amount: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    status: {
+      type: DataTypes.ENUM('성공', '실패', '취소', '처리중'),
+      allowNull: false
+    },
+    pg_tid: {
+      type: DataTypes.STRING(100),
+      allowNull: true
+    },
+    approved_at: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: true
+    }
+  }, {
+    tableName: 'payment',
+    timestamps: false,
+    underscored: true
+  });
+
+  Payment.associate = (models) => {
+    Payment.belongsTo(models.Order, {
+      foreignKey: 'order_id',
+      targetKey: 'order_id'
+    });
+  };
+
+  return Payment;
+};

--- a/server/models/product.js
+++ b/server/models/product.js
@@ -1,0 +1,123 @@
+// server/models/product.js
+module.exports = (sequelize, DataTypes) => {
+  const Product = sequelize.define('Product', {
+    product_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    category_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    seller_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    direct_store_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    title: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.ENUM('판매중', '품절', '판매 중지'),
+      allowNull: false,
+    },
+    weight: {
+      type: DataTypes.STRING(50),
+      allowNull: false,
+    },
+    price: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    intro: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    is_video: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+    },
+    video_url: {
+      type: DataTypes.STRING(500),
+      allowNull: true,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    returnable: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+    }
+  }, {
+    tableName: 'product',
+    timestamps: false,
+    underscored: true,
+  });
+
+  Product.associate = (models) => {
+    // Category 관계
+    Product.belongsTo(models.Category, {
+      foreignKey: 'category_id',
+      targetKey: 'category_id',
+    });
+
+    // Seller 관계
+    Product.belongsTo(models.Seller, {
+      foreignKey: 'seller_id',
+      targetKey: 'seller_id',
+    });
+
+    // DirectStore 관계
+    Product.belongsTo(models.DirectStore, {
+      foreignKey: 'direct_store_id',
+      targetKey: 'direct_store_id',
+    });
+
+    // Review 관계
+    // Product.hasMany(models.Review, {
+    //   foreignKey: 'product_id',
+    //   sourceKey: 'product_id',
+    // });
+
+    // ProductImg 관계
+    Product.hasMany(models.ProductImg, {
+      foreignKey: 'product_id',
+      sourceKey: 'product_id',
+    });
+
+    // OrderProduct 관계 추가!!
+    Product.hasMany(models.OrderProduct, {
+      foreignKey: 'product_id',
+      sourceKey: 'product_id',
+    });
+
+    // Wishlist 관계
+    // Product.hasMany(models.Wishlist, {
+    //   foreignKey: 'product_id',
+    //   sourceKey: 'product_id',
+    // });
+
+    // ProductDetailPage 관계
+    // Product.hasOne(models.ProductDetailPage, {
+    //   foreignKey: 'product_id',
+    //   sourceKey: 'product_id',
+    // });
+  };
+
+  return Product;
+};

--- a/server/models/product_img.js
+++ b/server/models/product_img.js
@@ -1,0 +1,40 @@
+// server/models/product_img.js
+module.exports = (sequelize, DataTypes) => {
+  const ProductImg = sequelize.define('ProductImg', {
+    img_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    product_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    img_url: {
+      type: DataTypes.STRING(500),
+      allowNull: false,
+    },
+    img_order: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    }
+  }, {
+    tableName: 'product_img',
+    timestamps: false,
+    underscored: true,
+  });
+
+  ProductImg.associate = (models) => {
+    ProductImg.belongsTo(models.Product, {
+      foreignKey: 'product_id',
+      // targetKey: 'product_id',
+    });
+  };
+
+  return ProductImg;
+};

--- a/server/models/product_wishlist.js
+++ b/server/models/product_wishlist.js
@@ -1,0 +1,40 @@
+// server/models/product_wishlist.js
+module.exports = (sequelize, DataTypes) => {
+  const ProductWishlist = sequelize.define('ProductWishlist', {
+    product_wishlist_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    product_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false
+    },
+    customer_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: true
+    }
+  }, {
+    tableName: 'product_wishlist',
+    timestamps: false,
+    underscored: true
+  });
+
+  ProductWishlist.associate = (models) => {
+    ProductWishlist.belongsTo(models.Product, {
+      foreignKey: 'product_id',
+      targetKey: 'product_id'
+    });
+    ProductWishlist.belongsTo(models.Customer, {
+      foreignKey: 'customer_id',
+      targetKey: 'customer_id'
+    });
+  };
+
+  return ProductWishlist;
+};

--- a/server/models/refund.js
+++ b/server/models/refund.js
@@ -1,0 +1,48 @@
+// server/models/refund.js
+module.exports = (sequelize, DataTypes) => {
+  const Refund = sequelize.define('Refund', {
+    refund_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    payment_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false
+    },
+    amount: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    reason: {
+      type: DataTypes.STRING(500),
+      allowNull: false
+    },
+    status: {
+      type: DataTypes.ENUM('완료', '거절', '요청됨', '승인됨'),
+      allowNull: false
+    },
+    refunded_at: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false
+    }
+  }, {
+    tableName: 'refund',
+    timestamps: false,
+    underscored: true
+  });
+
+  Refund.associate = (models) => {
+    Refund.belongsTo(models.Payment, {
+      foreignKey: 'payment_id',
+      targetKey: 'payment_id'
+    });
+  };
+
+  return Refund;
+};

--- a/server/models/review.js
+++ b/server/models/review.js
@@ -1,0 +1,52 @@
+// server/models/review.js
+module.exports = (sequelize, DataTypes) => {
+  const Review = sequelize.define('Review', {
+    review_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    customer_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    product_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    content: {
+      type: DataTypes.STRING(1000),
+      allowNull: false,
+    },
+    rating: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    img_url: {
+      type: DataTypes.STRING(200),
+      allowNull: true,
+    },
+    created_date: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    }
+  }, {
+    tableName: 'review',
+    timestamps: false,
+    underscored: true,
+  });
+
+  Review.associate = (models) => {
+    Review.belongsTo(models.Customer, {
+      foreignKey: 'customer_id',
+      targetKey: 'customer_id',
+    });
+    Review.belongsTo(models.Product, {
+      foreignKey: 'product_id',
+      targetKey: 'product_id',
+    });
+  };
+
+  return Review;
+};

--- a/server/models/seller.js
+++ b/server/models/seller.js
@@ -66,6 +66,14 @@ module.exports = (sequelize, DataTypes) => {
     timestamps: false,
     underscored: true,
   });
+  
+  // Store와의 관계 추가
+  Seller.associate = (models) => {
+    Seller.belongsTo(models.Store, {
+      foreignKey: 'store_id',
+      targetKey: 'store_id',
+    });
+  };
 
   return Seller;
 };

--- a/server/models/store_wishlist.js
+++ b/server/models/store_wishlist.js
@@ -1,0 +1,40 @@
+// server/models/store_wishlist.js
+module.exports = (sequelize, DataTypes) => {
+  const StoreWishlist = sequelize.define('StoreWishlist', {
+    store_wishlist_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    store_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false
+    },
+    customer_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: true
+    }
+  }, {
+    tableName: 'store_wishlist',
+    timestamps: false,
+    underscored: true
+  });
+
+  StoreWishlist.associate = (models) => {
+    StoreWishlist.belongsTo(models.Store, {
+      foreignKey: 'store_id',
+      targetKey: 'store_id'
+    });
+    StoreWishlist.belongsTo(models.Customer, {
+      foreignKey: 'customer_id',
+      targetKey: 'customer_id'
+    });
+  };
+
+  return StoreWishlist;
+};

--- a/server/models/voucher_product.js
+++ b/server/models/voucher_product.js
@@ -1,0 +1,38 @@
+
+module.exports = (sequelize, DataTypes) => {
+  const VoucherProduct = sequelize.define('VoucherProduct', {
+    voucher_id: {
+      type: DataTypes.BIGINT,
+      primaryKey: true,
+      allowNull: false
+    },
+    voucher_name: {
+      type: DataTypes.STRING(100),
+      allowNull: false
+    },
+    amount: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    valid_date: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    refundable_date: {
+      type: DataTypes.DATE,
+      allowNull: false
+    }
+  }, {
+    tableName: 'voucher_product',
+    timestamps: false
+  });
+
+  VoucherProduct.associate = models => {
+    VoucherProduct.hasMany(models.IssueVoucher, {
+      foreignKey: 'voucher_id',
+      sourceKey: 'voucher_id'
+    });
+  };
+
+  return VoucherProduct;
+};

--- a/server/models/voucher_usage.js
+++ b/server/models/voucher_usage.js
@@ -1,0 +1,42 @@
+
+module.exports = (sequelize, DataTypes) => {
+  const VoucherUsage = sequelize.define('VoucherUsage', {
+    voucher_usage_id: {
+      type: DataTypes.BIGINT,
+      primaryKey: true,
+      allowNull: false,
+    },
+    user_voucher_id: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    used_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    used_amount: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    remaining_amount: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    used_in: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  }, {
+    tableName: 'voucher_usage',
+    timestamps: false,
+  });
+
+  VoucherUsage.associate = models => {
+    VoucherUsage.belongsTo(models.IssueVoucher, {
+      foreignKey: 'user_voucher_id',
+      targetKey: 'user_voucher_id',
+    });
+  };
+
+  return VoucherUsage;
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,9 +3,11 @@ const jwt = require('jsonwebtoken');
 const router = express.Router();
 
 const authRoutes = require('./authRoutes'); 
+const mypageRoutes = require('./mypage-buyer') // 구매자 마이페이지
 
 router.use('/auth', authRoutes);
 
+router.use('/my', mypageRoutes);
 
 router.get('/', (req, res) => {
     res.send('Hello, Express');

--- a/server/routes/mypage-buyer/index.js
+++ b/server/routes/mypage-buyer/index.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+
+const profileRoutes = require('./profileRoutes'); // 프로필 조회/수정
+router.use('/profile', profileRoutes);
+
+const orderRoutes = require('./orderRoutes'); // 주문/배송 내역 조회
+router.use('/orders', orderRoutes);
+
+const refundRoutes = require('./refundRoutes'); // 취소/반품 내역 조회
+router.use('/cancel', refundRoutes);
+
+const wishlistRoutes = require('./wishlistRoutes'); // 스토어 즐겨찾기, 상품 찜 목록 조회
+router.use('/', wishlistRoutes);
+
+const reviewRoutes = require('./reviewRoutes'); // 리뷰 내역 조회
+router.use('/reviews', reviewRoutes);
+
+module.exports = router;
+

--- a/server/routes/mypage-buyer/orderRoutes.js
+++ b/server/routes/mypage-buyer/orderRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { getMyOrders, getMyOrderDetail } = require('../../controllers/mypage-buyer/orderController');
+const authMiddleware = require('../../middlewares/authMiddleware');
+
+router.get('/', authMiddleware, getMyOrders);
+router.get('/:order_id', authMiddleware, getMyOrderDetail);
+
+module.exports = router;

--- a/server/routes/mypage-buyer/profileRoutes.js
+++ b/server/routes/mypage-buyer/profileRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const authMiddleware = require('../../middlewares/authMiddleware');
+const { getProfile, updateProfile } = require('../../controllers/mypage-buyer/profileController');
+
+// 프로필 조회
+router.get('/', authMiddleware, getProfile);
+
+// 프로필 수정
+router.patch('/', authMiddleware, updateProfile);
+
+module.exports = router;

--- a/server/routes/mypage-buyer/refundRoutes.js
+++ b/server/routes/mypage-buyer/refundRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const authMiddleware = require('../../middlewares/authMiddleware');
+const { getMyCancellations, getCancellationDetail } = require('../../controllers/mypage-buyer/refundController');
+
+// 취소/반품 내역 조회
+router.get('/', authMiddleware, getMyCancellations);
+
+// 취소/반품 내역 상세 조회
+router.get('/:refund_id', authMiddleware, getCancellationDetail);
+
+module.exports = router;

--- a/server/routes/mypage-buyer/reviewRoutes.js
+++ b/server/routes/mypage-buyer/reviewRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const authMiddleware = require('../../middlewares/authMiddleware');
+const { getMyReviews } = require('../../controllers/mypage-buyer/reviewController');
+
+// 리뷰 내역 조회
+router.get('/', authMiddleware, getMyReviews);
+
+module.exports = router;

--- a/server/routes/mypage-buyer/wishlistRoutes.js
+++ b/server/routes/mypage-buyer/wishlistRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const authMiddleware = require('../../middlewares/authMiddleware');
+const { getFavoriteStores, getProductWishlists } = require('../../controllers/mypage-buyer/wishlistController');
+
+// 스토어 즐겨찾기 목록 조회
+router.get('/favorites', authMiddleware, getFavoriteStores);
+
+// 상품 찜 목록 조회
+router.get('/wishlists', authMiddleware, getProductWishlists);
+
+module.exports = router;


### PR DESCRIPTION
### 구현 내용
프로필 조회 
프로필 수정 
주문/배송 조회
주문/배송 상세 조회 
취소/반품 조회
취소/반품 상세 조회 
스토어 즐겨찾기 조회
상품 찜 조회  
리뷰 내역 조회

### 참고
- 상품 추천 기능 구현 후, 구매자 마이페이지 남은 기능(정기배송 신청 내역 조회, 쿠폰, 금액권, 문의 내역) 구현 예정
- 스토어 즐겨찾기 삭제 기능은 구현하지 않음. 추후 구현 예정.
- 구매자 마이페이지 코드는 controllers,  routes 하위의 mypage-buyer 폴더 내에 위치 